### PR TITLE
Fix for issue #13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 
-def jarVersion = "1.1.0"
+def jarVersion = "1.1.1"
 group = 'io.nats'
 
 def isMerge = System.getenv("BUILD_EVENT") == "push"

--- a/src/main/java/io/nats/jparse/node/BooleanNode.java
+++ b/src/main/java/io/nats/jparse/node/BooleanNode.java
@@ -125,9 +125,15 @@ public class BooleanNode implements ScalarNode {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        BooleanNode that = (BooleanNode) o;
-        return value == that.value;
+
+        if (o instanceof  BooleanNode) {
+            BooleanNode that = (BooleanNode) o;
+            return value == that.value;
+        } else if (o instanceof Boolean) {
+            Boolean that = (Boolean) o;
+            return value == that;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/io/nats/jparse/node/NumberNode.java
+++ b/src/main/java/io/nats/jparse/node/NumberNode.java
@@ -125,9 +125,33 @@ public class NumberNode extends Number implements ScalarNode, CharSequence {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        NumberNode other = (NumberNode) o;
-        return CharSequenceUtils.equals(this, other);
+        if (o == null) return false;
+
+        if (o instanceof NumberNode) {
+            NumberNode other = (NumberNode) o;
+            return CharSequenceUtils.equals(this, other);
+        } else if (o instanceof Number) {
+
+            switch (o.getClass().getName()) {
+                case "java.lang.Integer":
+                    return this.intValue() == (int) o;
+                case "java.lang.Long":
+                    return this.longValue() == (long) o;
+                case "java.lang.Float":
+                    return this.floatValue() == (float) o;
+                case "java.lang.Double":
+                    return this.doubleValue() == (double) o;
+                case "java.math.BigDecimal":
+                    return this.bigDecimalValue().equals(o);
+                case "java.math.BigInteger":
+                    return this.bigIntegerValue().equals(o);
+                default:
+                    return false;
+            }
+
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -163,4 +187,6 @@ public class NumberNode extends Number implements ScalarNode, CharSequence {
     public String toString() {
         return this.originalString();
     }
+
+
 }

--- a/src/main/java/io/nats/jparse/node/ObjectNode.java
+++ b/src/main/java/io/nats/jparse/node/ObjectNode.java
@@ -124,52 +124,52 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
 
     @Override
     public Set<Entry<CharSequence, Node>> entrySet() {
-        throw new UnsupportedOperationException();
-//
-//        return new AbstractSet<Entry<CharSequence, Node>>() {
-//
-//            @Override
-//            public boolean contains(Object o) {
-//                return keys().contains(o);
-//            }
-//
-//            @Override
-//            public Iterator<Entry<CharSequence, Node>> iterator() {
-//                final Iterator<CharSequence> iterator = keys().iterator();
-//                return new Iterator<Entry<CharSequence, Node>>() {
-//                    @Override
-//                    public boolean hasNext() {
-//                        return iterator.hasNext();
-//                    }
-//
-//                    @Override
-//                    public Entry<CharSequence, Node> next() {
-//                        CharSequence nextKey = iterator.next();
-//                        return new Entry<CharSequence, Node>() {
-//                            @Override
-//                            public CharSequence getKey() {
-//                                return nextKey;
-//                            }
-//
-//                            @Override
-//                            public Node getValue() {
-//                                return getObjectNode(nextKey);
-//                            }
-//
-//                            @Override
-//                            public Node setValue(Node value) {
-//                                throw new UnsupportedOperationException();
-//                            }
-//                        };
-//                    }
-//                };
-//            }
-//
-//            @Override
-//            public int size() {
-//                return keys().size();
-//            }
-//        };
+
+
+        return new AbstractSet<Entry<CharSequence, Node>>() {
+
+            @Override
+            public boolean contains(Object o) {
+                return keys().contains(o);
+            }
+
+            @Override
+            public Iterator<Entry<CharSequence, Node>> iterator() {
+                final Iterator<CharSequence> iterator = keys().iterator();
+                return new Iterator<Entry<CharSequence, Node>>() {
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Entry<CharSequence, Node> next() {
+                        final CharSequence nextKey = iterator.next().toString();
+                        return new Entry<CharSequence, Node>() {
+                            @Override
+                            public CharSequence getKey() {
+                                return nextKey;
+                            }
+
+                            @Override
+                            public Node getValue() {
+                                return lookupElement(nextKey);
+                            }
+
+                            @Override
+                            public Node setValue(Node value) {
+                                throw new UnsupportedOperationException();
+                            }
+                        };
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return keys().size();
+            }
+        };
 
     }
 

--- a/src/main/java/io/nats/jparse/node/ObjectNode.java
+++ b/src/main/java/io/nats/jparse/node/ObjectNode.java
@@ -24,6 +24,8 @@ import io.nats.jparse.token.TokenTypes;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ObjectNode extends AbstractMap<CharSequence, Node> implements CollectionNode {
 
@@ -108,6 +110,16 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
     @Override
     public int size() {
         return keys().size();
+    }
+
+    @Override
+    public Set<CharSequence> keySet() {
+        return keys().stream().map(CharSequence::toString).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<Node> values() {
+         return keys().stream().map(this::lookupElement).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/io/nats/jparse/node/ObjectNode.java
+++ b/src/main/java/io/nats/jparse/node/ObjectNode.java
@@ -96,53 +96,68 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
         return value instanceof NullNode ? null : value;
     }
 
+    public boolean containsKey(Object key) {
+       return  lookupElement((CharSequence) key) != null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return keys().isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return keys().size();
+    }
+
     @Override
     public Set<Entry<CharSequence, Node>> entrySet() {
-
-        return new AbstractSet<Entry<CharSequence, Node>>() {
-
-            @Override
-            public boolean contains(Object o) {
-                return keys().contains(o);
-            }
-
-            @Override
-            public Iterator<Entry<CharSequence, Node>> iterator() {
-                final Iterator<CharSequence> iterator = keys().iterator();
-                return new Iterator<Entry<CharSequence, Node>>() {
-                    @Override
-                    public boolean hasNext() {
-                        return iterator.hasNext();
-                    }
-
-                    @Override
-                    public Entry<CharSequence, Node> next() {
-                        CharSequence nextKey = iterator.next();
-                        return new Entry<CharSequence, Node>() {
-                            @Override
-                            public CharSequence getKey() {
-                                return nextKey;
-                            }
-
-                            @Override
-                            public Node getValue() {
-                                return getObjectNode(nextKey);
-                            }
-
-                            @Override
-                            public Node setValue(Node value) {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
-            }
-
-            @Override
-            public int size() {
-                return keys().size();
-            }
-        };
+        throw new UnsupportedOperationException();
+//
+//        return new AbstractSet<Entry<CharSequence, Node>>() {
+//
+//            @Override
+//            public boolean contains(Object o) {
+//                return keys().contains(o);
+//            }
+//
+//            @Override
+//            public Iterator<Entry<CharSequence, Node>> iterator() {
+//                final Iterator<CharSequence> iterator = keys().iterator();
+//                return new Iterator<Entry<CharSequence, Node>>() {
+//                    @Override
+//                    public boolean hasNext() {
+//                        return iterator.hasNext();
+//                    }
+//
+//                    @Override
+//                    public Entry<CharSequence, Node> next() {
+//                        CharSequence nextKey = iterator.next();
+//                        return new Entry<CharSequence, Node>() {
+//                            @Override
+//                            public CharSequence getKey() {
+//                                return nextKey;
+//                            }
+//
+//                            @Override
+//                            public Node getValue() {
+//                                return getObjectNode(nextKey);
+//                            }
+//
+//                            @Override
+//                            public Node setValue(Node value) {
+//                                throw new UnsupportedOperationException();
+//                            }
+//                        };
+//                    }
+//                };
+//            }
+//
+//            @Override
+//            public int size() {
+//                return keys().size();
+//            }
+//        };
 
     }
 

--- a/src/main/java/io/nats/jparse/node/ObjectNode.java
+++ b/src/main/java/io/nats/jparse/node/ObjectNode.java
@@ -95,6 +95,16 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
     @Override
     public Node get(Object key) {
         final Node value = getNode(key);
+//        if (value != null) {
+//            switch (value.getClass().getName()) {
+//                case "io.nats.jparse.node.NullNode":
+//                    return null;
+//                case "io.nats.jparse.node.BooleanNode":
+//                    BooleanNode bn = (BooleanNode) value;
+//                    return bn.booleanValue();
+//
+//            }
+//        }
         return value instanceof NullNode ? null : value;
     }
 

--- a/src/test/java/io/nats/jparse/JsonParserTest.java
+++ b/src/test/java/io/nats/jparse/JsonParserTest.java
@@ -643,7 +643,7 @@ class JsonParserTest {
         final ObjectNode j2 = jsonParser().parse(Json.niceJson(json)).asObject();
         assertEquals(j2, jsonObject);
 
-        jsonObject.entrySet().forEach(objectObjectEntry -> assertTrue(jsonObject.containsKey(objectObjectEntry.getKey())));
+        jsonObject.keySet().stream().forEach(key -> assertTrue(jsonObject.containsKey(key)));
     }
 
     @Test

--- a/src/test/java/io/nats/jparse/bugs/ParserBugs.java
+++ b/src/test/java/io/nats/jparse/bugs/ParserBugs.java
@@ -2,6 +2,7 @@ package io.nats.jparse.bugs;
 
 import io.nats.jparse.Json;
 import io.nats.jparse.node.BooleanNode;
+import io.nats.jparse.node.Node;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -56,7 +57,9 @@ public class ParserBugs {
         }
 
         try {
-            map.forEach((s, o) -> {
+            map.forEach((key, value) -> {
+                assertTrue(key.startsWith("key"));
+                assertTrue(value instanceof Node);
             });
 
         } catch (UnsupportedOperationException ex) {

--- a/src/test/java/io/nats/jparse/bugs/ParserBugs.java
+++ b/src/test/java/io/nats/jparse/bugs/ParserBugs.java
@@ -47,20 +47,21 @@ public class ParserBugs {
 
 
 
-        //Not all map methods work.
+        //All read map methods should work.
         try {
-            map.entrySet().iterator().next();
-            fail();
+            String key = map.entrySet().iterator().next().getKey();
+            assertTrue(key.startsWith("key"));
         } catch (UnsupportedOperationException ex) {
-            //This map does not support this.
+           fail();
         }
 
         try {
             map.forEach((s, o) -> {
             });
-            fail();
+
         } catch (UnsupportedOperationException ex) {
             //This map does not support this.
+            fail();
         }
         // Most map methods should work like getOrDefault, computeIfEmpty, computeIfPresent, etc.
     }

--- a/src/test/java/io/nats/jparse/bugs/ParserBugs.java
+++ b/src/test/java/io/nats/jparse/bugs/ParserBugs.java
@@ -60,6 +60,9 @@ public class ParserBugs {
             map.forEach((key, value) -> {
                 assertTrue(key.startsWith("key"));
                 assertTrue(value instanceof Node);
+                assertTrue(value instanceof Number || value instanceof List
+                            || value instanceof CharSequence
+                            || value instanceof BooleanNode);
             });
 
         } catch (UnsupportedOperationException ex) {

--- a/src/test/java/io/nats/jparse/bugs/ParserBugs.java
+++ b/src/test/java/io/nats/jparse/bugs/ParserBugs.java
@@ -1,10 +1,11 @@
 package io.nats.jparse.bugs;
 
 import io.nats.jparse.Json;
+import io.nats.jparse.node.BooleanNode;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,26 +16,52 @@ public class ParserBugs {
         //See https://github.com/nats-io/jparse/issues/13
 
         final Map<String, Object> map = Json.toMap("{ \"key\": \"value\"," +
-                " \"key2\": 123," +
-                " \"key3\": [1,2,3] }");
+                " \"key1\": 123," +
+                " \"key2\": [1,2,3], " +
+                " \"key3\": true }"
+                );
+
         assertTrue(map.containsKey("key"));
+        assertEquals(map.size(), 4);
+        assertFalse(map.isEmpty());
+
+        // Map contains CharSequence as values not strings (which is a StringNode)
+        assertTrue(map.get("key") instanceof CharSequence);
+        // Map does not have int, long, float, double, etc. but instead java.lang.Number (which is a NumberNode)
+        assertTrue(map.get("key1") instanceof Number);
+        // JSON arrays are java.util.List and JSON objects are java.util.Map.
+        assertTrue(map.get("key2") instanceof List);
+        final Set<String> keys = map.keySet();
+        assertEquals(new HashSet<>(Arrays.asList("key", "key1", "key2", "key3")),
+                keys);
+        Collection<Object> values = map.values();
+        assertEquals(4, values.size());
+
+
+        assertEquals("value", map.get("key").toString());
+        assertEquals( map.get("key"), "value");
+        assertEquals(123, ((Number)map.get("key1")).intValue());
+        assertEquals(map.get("key1"), 123);
+        assertTrue(((BooleanNode)map.get("key3")).booleanValue());
+        assertEquals(map.get("key3"),true );
+
+
+
+        //Not all map methods work.
         try {
             map.entrySet().iterator().next();
             fail();
         } catch (UnsupportedOperationException ex) {
             //This map does not support this.
         }
-        assertEquals("value", map.get("key").toString());
 
-        assertEquals( map.get("key"), "value");
-
-        assertTrue(map.get("key") instanceof CharSequence);
-        assertTrue(map.get("key2") instanceof Number);
-        assertTrue(map.get("key3") instanceof List);
-
-        assertEquals(123, ((Number)map.get("key2")).intValue());
-
-        assertEquals(map.get("key2"), 123);
-
+        try {
+            map.forEach((s, o) -> {
+            });
+            fail();
+        } catch (UnsupportedOperationException ex) {
+            //This map does not support this.
+        }
+        // Most map methods should work like getOrDefault, computeIfEmpty, computeIfPresent, etc.
     }
 }

--- a/src/test/java/io/nats/jparse/bugs/ParserBugs.java
+++ b/src/test/java/io/nats/jparse/bugs/ParserBugs.java
@@ -1,0 +1,40 @@
+package io.nats.jparse.bugs;
+
+import io.nats.jparse.Json;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParserBugs {
+
+    @Test
+    void issue13() {
+        //See https://github.com/nats-io/jparse/issues/13
+
+        final Map<String, Object> map = Json.toMap("{ \"key\": \"value\"," +
+                " \"key2\": 123," +
+                " \"key3\": [1,2,3] }");
+        assertTrue(map.containsKey("key"));
+        try {
+            map.entrySet().iterator().next();
+            fail();
+        } catch (UnsupportedOperationException ex) {
+            //This map does not support this.
+        }
+        assertEquals("value", map.get("key").toString());
+
+        assertEquals( map.get("key"), "value");
+
+        assertTrue(map.get("key") instanceof CharSequence);
+        assertTrue(map.get("key2") instanceof Number);
+        assertTrue(map.get("key3") instanceof List);
+
+        assertEquals(123, ((Number)map.get("key2")).intValue());
+
+        assertEquals(map.get("key2"), 123);
+
+    }
+}


### PR DESCRIPTION
#13 

```java

        final Map<String, Object> map = Json.toMap("{ \"key\": \"value\"," +
                " \"key1\": 123," +
                " \"key2\": [1,2,3], " +
                " \"key3\": true }"
                );

        assertTrue(map.containsKey("key"));
        assertEquals(map.size(), 4);
        assertFalse(map.isEmpty());

        // Map contains CharSequence as values not strings (which is a StringNode)
        assertTrue(map.get("key") instanceof CharSequence);
        // Map does not have int, long, float, double, etc. but instead java.lang.Number (which is a NumberNode)
        assertTrue(map.get("key1") instanceof Number);
        // JSON arrays are java.util.List and JSON objects are java.util.Map.
        assertTrue(map.get("key2") instanceof List);
        final Set<String> keys = map.keySet();
        assertEquals(new HashSet<>(Arrays.asList("key", "key1", "key2", "key3")),
                keys);
        Collection<Object> values = map.values();
        assertEquals(4, values.size());


        assertEquals("value", map.get("key").toString());
        assertEquals( map.get("key"), "value");
        assertEquals(123, ((Number)map.get("key1")).intValue());
        assertEquals(map.get("key1"), 123);
        assertTrue(((BooleanNode)map.get("key3")).booleanValue());
        assertEquals(map.get("key3"),true );



        //Not all map methods work.
        try {
            map.entrySet().iterator().next();
            fail();
        } catch (UnsupportedOperationException ex) {
            //This map does not support this.
        }

        try {
            map.forEach((s, o) -> {
            });
            fail();
        } catch (UnsupportedOperationException ex) {
            //This map does not support this.
        }
        // Most map methods should work like getOrDefault, computeIfEmpty, computeIfPresent, etc.
```